### PR TITLE
allow special characters for password

### DIFF
--- a/src/Soap/ClientDecorator/AuthenticationDecorator.php
+++ b/src/Soap/ClientDecorator/AuthenticationDecorator.php
@@ -84,7 +84,7 @@ XML;
             self::WSSE_NS,
             'wsse',
             new \SoapVar(
-                sprintf($xml, self::WSSE_NS, $this->username, self::WSSE_PASSWORD_TYPE, $this->password),
+                sprintf($xml, self::WSSE_NS, $this->username, self::WSSE_PASSWORD_TYPE, htmlspecialchars($this->password)),
                 XSD_ANYXML
             )
         );


### PR DESCRIPTION
passwords with special characters (like "&") creates an error on the external ressource.

**example**:

Password: ab&cd#123

response:

Error reading XMLStreamReader: Unexpected character '#' (code 35); expected a semi-colon after the reference for entity 'cd'
 at [row,col {unknown-source}]: [5,132]
